### PR TITLE
chore: transfer ownership to async-learning team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@
 # @Multiverse-io/lobsters will be requested for
 # review when someone opens a pull request.
 
-*       @Multiverse-io/lobsters
+*       @Multiverse-io/async-learning @Multiverse-io/lobsters

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -14,5 +14,5 @@ metadata:
       url: https://github.com/Multiverse-io/amazon-ecs-register-task-definition
 spec:
   type: library
-  owner: lobsters
+  owner: async-learning
   lifecycle: production


### PR DESCRIPTION
## Summary

- Added `@Multiverse-io/async-learning` to `CODEOWNERS` alongside the existing `@Multiverse-io/lobsters` team
- Updated `catalog-info.yaml` owner from `lobsters` to `async-learning`

Part of the team ownership migration to async-learning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates CODEOWNERS and Backstage `catalog-info.yaml` metadata with no runtime or behavior changes.
> 
> **Overview**
> **Ownership metadata is migrated to the async-learning team.** `CODEOWNERS` now requests review from `@Multiverse-io/async-learning` alongside `@Multiverse-io/lobsters` for all paths.
> 
> Backstage `catalog-info.yaml` updates the component `owner` from `lobsters` to `async-learning`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77a2ccc080414a83510c4fbe86114daa8c3bd854. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->