### PR TITLE
chore: remove old codeowner from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-# @Multiverse-io/lobsters will be requested for
+# @Multiverse-io/async-learning will be requested for
 # review when someone opens a pull request.
 
-*       @Multiverse-io/async-learning @Multiverse-io/lobsters
+*       @Multiverse-io/async-learning


### PR DESCRIPTION
Removes the old team entry from CODEOWNERS as part of the post team name migration cleanup (ASY-974).

The only codeowner should be `@Multiverse-io/async-learning`.

Closes https://linear.app/multiverse-io/issue/ASY-2233

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes GitHub review ownership rules; no product code or runtime behavior is affected.
> 
> **Overview**
> Updates `CODEOWNERS` so the default owner for the entire repo is only `@Multiverse-io/async-learning`, removing the legacy `@Multiverse-io/lobsters` team reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5dbd824e63371ce133879c35e2e17f4e94d9419. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->